### PR TITLE
Improve env configuration and fix tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ DATABASE_PATH=cryptopilot.sqlite
 EXPRESS_SERVER_URL=http://localhost:5002
 FLASK_SERVER_URL=http://localhost:5001
 TEST_DATABASE_PATH=cryptopilot_test.sqlite
+ROBINHOOD_BALANCE_URL=http://localhost:5001/api/robinhood-balance
+ROBINHOOD_LAST_TRADE_URL=http://localhost:5001/api/robinhood-last-trade
+ROBINHOOD_AUTHENTICATE_URL=http://localhost:5001/api/authenticate-robinhood

--- a/express-backend/routes/exchangeRoutes.js
+++ b/express-backend/routes/exchangeRoutes.js
@@ -1,5 +1,3 @@
-// temp modified files
-
 const express = require("express");
 const router = express.Router();
 const { ExchangeKeys } = require("../models/models");

--- a/express-backend/services/helpers.js
+++ b/express-backend/services/helpers.js
@@ -2,12 +2,19 @@
 
 const axios = require("axios");
 
-// Configuration
+// Build service URLs from environment variables so deployments can override
+const FLASK_SERVER_URL = process.env.FLASK_SERVER_URL || "http://localhost:5001";
+
 const config = {
-  ROBINHOOD_BALANCE_URL: "http://localhost:5001/api/robinhood-balance",
-  ROBINHOOD_LAST_TRADE_URL: "http://localhost:5001/api/robinhood-last-trade",
+  ROBINHOOD_BALANCE_URL:
+    process.env.ROBINHOOD_BALANCE_URL ||
+    `${FLASK_SERVER_URL}/api/robinhood-balance`,
+  ROBINHOOD_LAST_TRADE_URL:
+    process.env.ROBINHOOD_LAST_TRADE_URL ||
+    `${FLASK_SERVER_URL}/api/robinhood-last-trade`,
   ROBINHOOD_AUTHENTICATE_URL:
-    "http://localhost:5001/api/authenticate-robinhood",
+    process.env.ROBINHOOD_AUTHENTICATE_URL ||
+    `${FLASK_SERVER_URL}/api/authenticate-robinhood`,
 };
 
 const reAuthenticateWithRobinhood = async (credentials) => {

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -3,10 +3,10 @@
 from flask import Flask
 from flask_cors import CORS
 from flask_migrate import Migrate
-from extensions import jwt, cors as ext_cors
-from routes.robinhood_routes import robinhood_bp
-from routes.other_exchanges_routes import other_exchanges_bp
-from models.models import db
+from flask_backend.extensions import jwt, cors as ext_cors
+from flask_backend.routes.robinhood_routes import robinhood_bp
+from flask_backend.routes.other_exchanges_routes import other_exchanges_bp
+from flask_backend.models.models import db
 
 
 def create_app():

--- a/flask_backend/controllers/robinhood_controller.py
+++ b/flask_backend/controllers/robinhood_controller.py
@@ -1,6 +1,6 @@
 # controllers/robinhood_controller.py
 
-from services.authenticate_with_robinhood import authenticate_with_robinhood
+from flask_backend.services.authenticate_with_robinhood import authenticate_with_robinhood
 # flask_backend\utils\database_operations.py
 
 

--- a/flask_backend/models/__init__.py
+++ b/flask_backend/models/__init__.py
@@ -1,0 +1,10 @@
+from flask_backend.models.models import db, ExchangeUser, Trade, Transaction, Deposit, Balance
+
+__all__ = [
+    "db",
+    "ExchangeUser",
+    "Trade",
+    "Transaction",
+    "Deposit",
+    "Balance",
+]

--- a/flask_backend/models/models.py
+++ b/flask_backend/models/models.py
@@ -25,29 +25,47 @@ class Trade(db.Model):
     __tablename__ = 'trade'
 
     trade_id = db.Column(db.Integer, primary_key=True, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey(
-        'exchange_user.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey('exchange_user.id'), nullable=False
+    )
+    symbol = db.Column(db.String(20), nullable=False)
+    side = db.Column(db.String(4), nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
+    price = db.Column(db.Float, nullable=False)
+    executed_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
 class Transaction(db.Model):
     __tablename__ = 'transaction'
 
     transaction_id = db.Column(db.Integer, primary_key=True, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey(
-        'exchange_user.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey('exchange_user.id'), nullable=False
+    )
+    amount = db.Column(db.Float, nullable=False)
+    type = db.Column(db.String(20), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
 class Deposit(db.Model):
     __tablename__ = 'deposit'
 
     deposit_id = db.Column(db.Integer, primary_key=True, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey(
-        'exchange_user.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey('exchange_user.id'), nullable=False
+    )
+    amount = db.Column(db.Float, nullable=False)
+    deposited_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
 class Balance(db.Model):
     __tablename__ = 'balance'
 
     balance_id = db.Column(db.Integer, primary_key=True, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey(
-        'exchange_user.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey('exchange_user.id'), nullable=False
+    )
+    asset = db.Column(db.String(50), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/flask_backend/routes/robinhood_routes.py
+++ b/flask_backend/routes/robinhood_routes.py
@@ -1,7 +1,7 @@
 # flask_backend\routes\robinhood_routes.py
 
 from flask import Blueprint, request, jsonify
-from controllers import robinhood_controller
+from flask_backend.controllers import robinhood_controller
 
 robinhood_bp = Blueprint('robinhood', __name__)
 

--- a/flask_backend/services/authenticate_with_robinhood.py
+++ b/flask_backend/services/authenticate_with_robinhood.py
@@ -2,7 +2,10 @@
 
 import pyotp
 import robin_stocks.robinhood as r
-from utils.database_operations import fetch_token_from_db, save_token_to_db
+from flask_backend.utils.database_operations import (
+    fetch_token_from_db,
+    save_token_to_db,
+)
 # flask_backend\utils\database_operations.py
 
 

--- a/flask_backend/tests/app/test_app.py
+++ b/flask_backend/tests/app/test_app.py
@@ -1,10 +1,7 @@
 import pytest
 from flask import Flask
-from ...app import create_app
-from ...models import db
-import sys
-
-sys.path.append('C:\\Users\\theca\\cryptopilot')
+from flask_backend.app import create_app
+from flask_backend.models import db
 
 
 @pytest.fixture

--- a/flask_backend/tests/controllers/test_controllers.py
+++ b/flask_backend/tests/controllers/test_controllers.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch, Mock
-from controllers.robinhood_controller import authenticate_robinhood_controller
+from flask_backend.controllers.robinhood_controller import authenticate_robinhood_controller
 
 
 def test_authenticate_robinhood_controller_success():
@@ -14,7 +14,7 @@ def test_authenticate_robinhood_controller_success():
     }
 
     # Mocking the service call to return True (successful authentication)
-    with patch('controllers.robinhood_controller.authenticate_with_robinhood', return_value=True):
+    with patch('flask_backend.controllers.robinhood_controller.authenticate_with_robinhood', return_value=True):
         response, status_code = authenticate_robinhood_controller(mock_request)
 
     assert status_code == 200
@@ -33,7 +33,7 @@ def test_authenticate_robinhood_controller_failure():
     }
 
     # Mocking the service call to return False (failed authentication)
-    with patch('controllers.robinhood_controller.authenticate_with_robinhood', return_value=False):
+    with patch('flask_backend.controllers.robinhood_controller.authenticate_with_robinhood', return_value=False):
         response, status_code = authenticate_robinhood_controller(mock_request)
 
     assert status_code == 401

--- a/flask_backend/tests/models/test_models.py
+++ b/flask_backend/tests/models/test_models.py
@@ -48,20 +48,74 @@ def test_exchange_user_creation(test_database):
 
 
 def test_trade_creation_and_relationship(test_database):
-    # Placeholder test for when the Trade model is expanded
-    pass
+    user = ExchangeUser(username="tradeuser",
+                        session_token="tradetoken",
+                        token_expiry=datetime.utcnow())
+    test_database.session.add(user)
+    test_database.session.commit()
+
+    trade = Trade(user_id=user.id,
+                  symbol="BTCUSD",
+                  side="buy",
+                  quantity=1.5,
+                  price=20000.0)
+    test_database.session.add(trade)
+    test_database.session.commit()
+
+    retrieved = Trade.query.filter_by(trade_id=trade.trade_id).first()
+    assert retrieved is not None
+    assert retrieved.user_id == user.id
 
 
 def test_transaction_creation_and_relationship(test_database):
-    # Placeholder test for when the Transaction model is expanded
-    pass
+    user = ExchangeUser(username="transuser",
+                        session_token="transtoken",
+                        token_expiry=datetime.utcnow())
+    test_database.session.add(user)
+    test_database.session.commit()
+
+    txn = Transaction(user_id=user.id,
+                      amount=100.0,
+                      type="withdrawal")
+    test_database.session.add(txn)
+    test_database.session.commit()
+
+    retrieved = Transaction.query.filter_by(transaction_id=txn.transaction_id).first()
+    assert retrieved is not None
+    assert retrieved.user_id == user.id
 
 
 def test_deposit_creation_and_relationship(test_database):
-    # Placeholder test for when the Deposit model is expanded
-    pass
+    user = ExchangeUser(username="depouser",
+                        session_token="depotoken",
+                        token_expiry=datetime.utcnow())
+    test_database.session.add(user)
+    test_database.session.commit()
+
+    dep = Deposit(user_id=user.id,
+                  amount=500.0)
+    test_database.session.add(dep)
+    test_database.session.commit()
+
+    retrieved = Deposit.query.filter_by(deposit_id=dep.deposit_id).first()
+    assert retrieved is not None
+    assert retrieved.user_id == user.id
 
 
 def test_balance_creation_and_relationship(test_database):
-    # Placeholder test for when the Balance model is expanded
-    pass
+    user = ExchangeUser(username="baluser",
+                        session_token="baltoken",
+                        token_expiry=datetime.utcnow())
+    test_database.session.add(user)
+    test_database.session.commit()
+
+    bal = Balance(user_id=user.id,
+                  asset="BTC",
+                  amount=1.23)
+    test_database.session.add(bal)
+    test_database.session.commit()
+
+    retrieved = Balance.query.filter_by(balance_id=bal.balance_id).first()
+    assert retrieved is not None
+    assert retrieved.user_id == user.id
+

--- a/flask_backend/tests/routes/test_routes.py
+++ b/flask_backend/tests/routes/test_routes.py
@@ -2,7 +2,7 @@
 import pytest
 from flask import Flask, jsonify
 from unittest.mock import patch
-from routes.robinhood_routes import robinhood_bp
+from flask_backend.routes.robinhood_routes import robinhood_bp
 from .mocks.robinhood_mocks import (mock_authenticate_robinhood_controller,
                                     mocked_authenticate_success,
                                     mocked_authenticate_failure,
@@ -23,7 +23,7 @@ def test_client(app):
 
 
 def test_authenticate_endpoint(test_client):
-    with patch('routes.robinhood_routes.robinhood_controller.authenticate_robinhood_controller',
+    with patch('flask_backend.routes.robinhood_routes.robinhood_controller.authenticate_robinhood_controller',
                side_effect=mock_authenticate_robinhood_controller):
 
         # Successful authentication scenario
@@ -45,7 +45,7 @@ def test_authenticate_endpoint(test_client):
         assert response.get_json() == mocked_authenticate_failure
 
 
-@patch('routes.robinhood_routes.robinhood_controller.fetch_robinhood_balance_controller',
+@patch('flask_backend.routes.robinhood_routes.robinhood_controller.fetch_robinhood_balance_controller',
        return_value=(mocked_balance_data, 200))
 def test_balance_endpoint(mock_fetch_balance, test_client):
     response = test_client.get('/balance')
@@ -53,7 +53,7 @@ def test_balance_endpoint(mock_fetch_balance, test_client):
     assert response.get_json() == mocked_balance_data
 
 
-@patch('routes.robinhood_routes.robinhood_controller.fetch_robinhood_last_trade_controller',
+@patch('flask_backend.routes.robinhood_routes.robinhood_controller.fetch_robinhood_last_trade_controller',
        return_value=(mocked_last_trade_data, 200))
 def test_last_trade_endpoint(mock_fetch_last_trade, test_client):
     response = test_client.get('/last-trade')

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running Express tests"
+(cd express-backend && npm test)
+
+echo "Running Flask tests"
+PYTHONPATH=$(pwd) pytest flask_backend


### PR DESCRIPTION
## Summary
- load Robinhood service URLs from environment variables
- clean up `exchangeRoutes.js`
- remove platform-specific path from tests and use package imports
- expand SQLAlchemy models and add simple unit tests
- add script to run both Express and Flask tests
- update internal imports to use package paths
- document new env vars

## Testing
- `npm test --prefix express-backend`
- `pytest flask_backend` *(fails: AttributeError in controllers)*

------
https://chatgpt.com/codex/tasks/task_e_6886ebce17dc832e97fe78d019e17817